### PR TITLE
Update getRandomNode() to work with credentials:

### DIFF
--- a/Cassandra/Cluster.php
+++ b/Cassandra/Cluster.php
@@ -25,32 +25,24 @@ class Cluster {
 	}
 
 	/**
+	 * Returns a random node from the cluster's node list
 	 * @throws \InvalidArgumentException
 	 * @throws Exception\ClusterException
 	 * @return Node|null
 	 */
 	public function getRandomNode() {
 		if (empty($this->nodes)) throw new ClusterException('Node list is empty.');
-		shuffle($this->nodes);
-		while(!empty($this->nodes)) {
-			$host = end($this->nodes);
-			try {
-				if ((array)$host === $host) {
-					$nodeKey = key($this->nodes);
-					$node = new Node($nodeKey, $host);
-					unset($this->nodes[$nodeKey]);
-				} else {
-					$node = new Node($host);
-					unset($this->nodes[$host]);
-				}
-				break;
-			} catch (\InvalidArgumentException $e) {
-				trigger_error($e->getMessage());
-			}
+		$randomKey = array_rand($this->nodes);
+		$randomValue = $this->nodes[$randomKey];
+		$node = null;
+		if (is_array($randomValue)) {
+			// $randomKey is an IP address and $randomValue is an array of options we pass to Node.
+			$node = new Node($randomKey, $randomValue);
+		} else {
+			// $randomKey is an index and $randomValue is the IP address of the node.
+			$node = new Node($randomValue);
 		}
-
-		if (empty($node)) throw new \InvalidArgumentException('Incorrect connection parameters for all nodes.');
-
+		unset($this->nodes[$randomKey]);
 		return $node;
 	}
 }


### PR DESCRIPTION
- Providing credientials in the form:
  
  ``` php
      new Cassandra\Database([
        '192.168.0.2:8882' => [
          'username' => 'admin',
          'password' => 'pass',
        ], 'my_keyspace');
  ```
  
  as the documentation suggests previously failed due to the use of
  `array_shuffle` which squashes non-numerical keys into int indexes.
- This commit fixes the issue by using `array_rand` which preserves the
  keys.
