### PR TITLE
Restructure: Rename Cassandra folder to src. Add vendor namespace across all files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor
+coverage

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $nodes = [
 ];
 
 // Connect to database.
-$database = new Cassandra\Database($nodes, 'my_keyspace');
+$database = new evseevnn\Cassandra\Database($nodes, 'my_keyspace');
 $database->connect();
 
 // Run query.

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
 		"php": ">=5.4.0"
 	},
 	"autoload": {
-		"psr-4": { "Cassandra\\": "Cassandra/" }
+		"psr-4": { "evseevnn\\Cassandra\\": "src/" }
 	}
 }

--- a/src/Cluster.php
+++ b/src/Cluster.php
@@ -1,7 +1,7 @@
 <?php
-namespace Cassandra;
-use Cassandra\Cluster\Node;
-use Cassandra\Exception\ClusterException;
+namespace evseevnn\Cassandra;
+use evseevnn\Cassandra\Cluster\Node;
+use evseevnn\Cassandra\Exception\ClusterException;
 
 class Cluster {
 

--- a/src/Cluster/Node.php
+++ b/src/Cluster/Node.php
@@ -1,7 +1,7 @@
 <?php
-namespace Cassandra\Cluster;
+namespace evseevnn\Cassandra\Cluster;
 
-use Cassandra\Exception\ConnectionException;
+use evseevnn\Cassandra\Exception\ConnectionException;
 
 class Node {
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -1,11 +1,11 @@
 <?php
-namespace Cassandra;
-use Cassandra\Cluster\Node;
-use Cassandra\Enum;
-use Cassandra\Exception\ConnectionException;
-use Cassandra\Protocol\Frame;
-use Cassandra\Protocol\Request;
-use Cassandra\Protocol\Response;
+namespace evseevnn\Cassandra;
+use evseevnn\Cassandra\Cluster\Node;
+use evseevnn\Cassandra\Enum;
+use evseevnn\Cassandra\Exception\ConnectionException;
+use evseevnn\Cassandra\Protocol\Frame;
+use evseevnn\Cassandra\Protocol\Request;
+use evseevnn\Cassandra\Protocol\Response;
 
 class Connection {
 
@@ -56,7 +56,7 @@ class Connection {
 
 	/**
 	 * @param Request $request
-	 * @return \Cassandra\Protocol\Response
+	 * @return \evseevnn\Cassandra\Protocol\Response
 	 */
 	public function sendRequest(Request $request) {
 		$frame = new Frame(Enum\VersionEnum::REQUEST, $request->getType(), $request);
@@ -94,7 +94,7 @@ class Connection {
 	}
 
 	/**
-	 * @return \Cassandra\Cluster\Node
+	 * @return \evseevnn\Cassandra\Cluster\Node
 	 */
 	public function getNode() {
 		return $this->node;

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,12 +1,12 @@
 <?php
-namespace Cassandra;
-use Cassandra\Enum\ConsistencyEnum;
-use Cassandra\Enum\OpcodeEnum;
-use Cassandra\Exception\CassandraException;
-use Cassandra\Exception\ConnectionException;
-use Cassandra\Exception\QueryException;
-use Cassandra\Protocol\RequestFactory;
-use Cassandra\Protocol\Response\Rows;
+namespace evseevnn\Cassandra;
+use evseevnn\Cassandra\Enum\ConsistencyEnum;
+use evseevnn\Cassandra\Enum\OpcodeEnum;
+use evseevnn\Cassandra\Exception\CassandraException;
+use evseevnn\Cassandra\Exception\ConnectionException;
+use evseevnn\Cassandra\Exception\QueryException;
+use evseevnn\Cassandra\Protocol\RequestFactory;
+use evseevnn\Cassandra\Protocol\Response\Rows;
 
 class Database {
 

--- a/src/Enum/ConsistencyEnum.php
+++ b/src/Enum/ConsistencyEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class ConsistencyEnum {
 	const CONSISTENCY_ANY = 0x0000;

--- a/src/Enum/DataTypeEnum.php
+++ b/src/Enum/DataTypeEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class DataTypeEnum {
 	const CUSTOM = 0x0000;

--- a/src/Enum/ErrorCodesEnum.php
+++ b/src/Enum/ErrorCodesEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class ErrorCodesEnum {
 	const SERVER_ERROR = 0x0000;

--- a/src/Enum/FlagsEnum.php
+++ b/src/Enum/FlagsEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class FlagsEnum {
 	const COMPRESSION = 0x01;

--- a/src/Enum/OpcodeEnum.php
+++ b/src/Enum/OpcodeEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class OpcodeEnum {
 	const ERROR = 0x00;

--- a/src/Enum/ResultTypeEnum.php
+++ b/src/Enum/ResultTypeEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class ResultTypeEnum {
 	const VOID = 0x0001;

--- a/src/Enum/VersionEnum.php
+++ b/src/Enum/VersionEnum.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Enum;
+namespace evseevnn\Cassandra\Enum;
 
 class VersionEnum {
 	const REQUEST = 0x01;

--- a/src/Exception/CassandraException.php
+++ b/src/Exception/CassandraException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Cassandra\Exception;
+namespace evseevnn\Cassandra\Exception;
 
 class CassandraException extends \Exception {}

--- a/src/Exception/ClusterException.php
+++ b/src/Exception/ClusterException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Cassandra\Exception;
+namespace evseevnn\Cassandra\Exception;
 
 class ClusterException extends \Exception {}

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Cassandra\Exception;
+namespace evseevnn\Cassandra\Exception;
 
 class ConnectionException extends \Exception {}

--- a/src/Exception/QueryException.php
+++ b/src/Exception/QueryException.php
@@ -1,4 +1,4 @@
 <?php
-namespace Cassandra\Exception;
+namespace evseevnn\Cassandra\Exception;
 
 class QueryException extends \Exception {}

--- a/src/Exception/ResponseExceprion.php
+++ b/src/Exception/ResponseExceprion.php
@@ -1,4 +1,4 @@
 <?php
-namespace Cassandra\Exception;
+namespace evseevnn\Cassandra\Exception;
 
 class ResponseException extends \Exception {}

--- a/src/Protocol/BinaryData.php
+++ b/src/Protocol/BinaryData.php
@@ -1,6 +1,6 @@
 <?php
-namespace Cassandra\Protocol;
-use Cassandra\Enum\DataTypeEnum;
+namespace evseevnn\Cassandra\Protocol;
+use evseevnn\Cassandra\Enum\DataTypeEnum;
 
 class BinaryData {
 

--- a/src/Protocol/Frame.php
+++ b/src/Protocol/Frame.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Protocol;
+namespace evseevnn\Cassandra\Protocol;
 
 class Frame {
 

--- a/src/Protocol/Request.php
+++ b/src/Protocol/Request.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Protocol;
+namespace evseevnn\Cassandra\Protocol;
 
 class Request {
 

--- a/src/Protocol/RequestFactory.php
+++ b/src/Protocol/RequestFactory.php
@@ -1,6 +1,6 @@
 <?php
-namespace Cassandra\Protocol;
-use Cassandra\Enum\OpcodeEnum;
+namespace evseevnn\Cassandra\Protocol;
+use evseevnn\Cassandra\Enum\OpcodeEnum;
 
 final class RequestFactory {
 
@@ -24,7 +24,7 @@ final class RequestFactory {
 	 * This is optional, if not specified no compression will be used.
 	 *
 	 * @param array $option
-	 * @return \Cassandra\Protocol\Request
+	 * @return \evseevnn\Cassandra\Protocol\Request
 	 */
 	public static function startup(array $option = []) {
 		$body = pack('n', count($option));
@@ -53,7 +53,7 @@ final class RequestFactory {
 	 *
 	 * @param string $user
 	 * @param string $password
-	 * @return \Cassandra\Protocol\Request
+	 * @return \evseevnn\Cassandra\Protocol\Request
 	 */
 	public static function credentials($user, $password) {
 		$body = pack('n', 2);
@@ -90,7 +90,7 @@ final class RequestFactory {
 	 *
 	 * @param string $cql
 	 * @param int $consistency
-	 * @return \Cassandra\Protocol\Request
+	 * @return \evseevnn\Cassandra\Protocol\Request
 	 */
 	public static function query($cql, $consistency) {
 		$body = pack('N', strlen($cql)) . $cql . pack('n', $consistency);
@@ -107,7 +107,7 @@ final class RequestFactory {
 	 * see Section 4.2.5).
 	 *
 	 * @param string $cql
-	 * @return \Cassandra\Protocol\Request
+	 * @return \evseevnn\Cassandra\Protocol\Request
 	 */
 	public static function prepare($cql) {
 		$body = pack('N', strlen($cql)) . $cql;
@@ -133,7 +133,7 @@ final class RequestFactory {
 	 * @param array $prepareData
 	 * @param array $values
 	 * @param int $consistency
-	 * @return \Cassandra\Protocol\Request
+	 * @return \evseevnn\Cassandra\Protocol\Request
 	 */
 	public static function execute(array $prepareData, array $values, $consistency) {
 		$body = pack('n', strlen($prepareData['id'])) . $prepareData['id'];

--- a/src/Protocol/Response.php
+++ b/src/Protocol/Response.php
@@ -1,13 +1,13 @@
 <?php
-namespace Cassandra\Protocol;
-use Cassandra\Enum\DataTypeEnum;
-use Cassandra\Enum\ErrorCodesEnum;
-use Cassandra\Enum\OpcodeEnum;
-use Cassandra\Enum\ResultTypeEnum;
-use Cassandra\Exception\ResponseException;
-use Cassandra\Protocol\Response\DataStream;
-use Cassandra\Protocol\Response\DataStream\TypeReader;
-use Cassandra\Protocol\Response\Rows;
+namespace evseevnn\Cassandra\Protocol;
+use evseevnn\Cassandra\Enum\DataTypeEnum;
+use evseevnn\Cassandra\Enum\ErrorCodesEnum;
+use evseevnn\Cassandra\Enum\OpcodeEnum;
+use evseevnn\Cassandra\Enum\ResultTypeEnum;
+use evseevnn\Cassandra\Exception\ResponseException;
+use evseevnn\Cassandra\Protocol\Response\DataStream;
+use evseevnn\Cassandra\Protocol\Response\DataStream\TypeReader;
+use evseevnn\Cassandra\Protocol\Response\Rows;
 
 class Response {
 

--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -1,7 +1,7 @@
 <?php
-namespace Cassandra\Protocol\Response;
+namespace evseevnn\Cassandra\Protocol\Response;
 
-use Cassandra\Enum\DataTypeEnum;
+use evseevnn\Cassandra\Enum\DataTypeEnum;
 
 class DataStream {
 

--- a/src/Protocol/Response/DataStream/TypeReader.php
+++ b/src/Protocol/Response/DataStream/TypeReader.php
@@ -1,7 +1,7 @@
 <?php
-namespace Cassandra\Protocol\Response\DataStream;
-use Cassandra\Enum\DataTypeEnum;
-use Cassandra\Protocol\Response\DataStream;
+namespace evseevnn\Cassandra\Protocol\Response\DataStream;
+use evseevnn\Cassandra\Enum\DataTypeEnum;
+use evseevnn\Cassandra\Protocol\Response\DataStream;
 
 final class TypeReader {
 

--- a/src/Protocol/Response/Rows.php
+++ b/src/Protocol/Response/Rows.php
@@ -1,5 +1,5 @@
 <?php
-namespace Cassandra\Protocol\Response;
+namespace evseevnn\Cassandra\Protocol\Response;
 
 class Rows implements \Iterator, \Countable {
 


### PR DESCRIPTION
This is a **breaking change** to add a vendor namespace and restructure the project in preparation for adding unit tests.

The `.gitignore` now contains entries for `vendor` and `coverage`. The `coverage` entry is for future use with code coverage reports.
