### PR TITLE
potential fix for usage of ints in sets

### DIFF
--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -64,9 +64,13 @@ class DataStream {
 	 *
 	 * @return int
 	 */
-	public function readInt() {
-		return unpack('N', $this->read(4))[1];
-	}
+    public function readInt($isCollectionElement = false) {
+        if ($isCollectionElement) {
+            $length = $this->readShort();
+            return unpack('N', $this->read($length))[1];
+        }
+        return unpack('N', $this->read(4))[1];
+    }
 
 	/**
 	 * Read string.
@@ -141,7 +145,7 @@ class DataStream {
 		$list = array();
 		$count = $this->readShort();
 		for ($i = 0; $i < $count; ++$i) {
-			$list[] = $this->readByType($valueType);
+			$list[] = $this->readByType($valueType, true);
 		}
 		return $list;
 	}
@@ -247,7 +251,7 @@ class DataStream {
 			case DataTypeEnum::FLOAT:
 				return $this->readFloat();
 			case DataTypeEnum::INT:
-				return $this->readInt();
+				return $this->readInt($isCollectionElement);
 			case DataTypeEnum::TIMESTAMP:
 				return $this->readTimestamp();
 			case DataTypeEnum::UUID:


### PR DESCRIPTION
Hey, thanks for the great contribution so far, we found one potential issue with ints in sets (its potentially there with more types that we did not test yet) and fixed it.

Our test case looked like this:

``` php
        $connection->query('CREATE TABLE map_table (k int, j list<int>, PRIMARY KEY(k))');
        $connection->query('INSERT INTO map_table (k,j) VALUES (:k,:j)', ['k' => 1, 'j' => [2,2]]);
        $connection->query('INSERT INTO map_table (k,j) VALUES (:k,:j)', ['k' => 2, 'j' => [3,3]]);
        $result = $connection->query('SELECT * from map_table WHERE k=2');
        $this->assertEquals(2, $result['k']);
        $this->assertEquals([3,3], $result['j']);
```

phpunit complained with

``` php
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 3
-    1 => 3
+    0 => 262144
+    1 => 196612
 )
```

After writing this fix we got our expected result and did not break any of our other tests in the suite.
