### PR TITLE
Reset the stored result type after logging in

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -82,6 +82,7 @@ class Database {
 						$nodeOptions['password']
 					)
 				);
+				$responseType = $response->getType();
 		}
 		if ($responseType === OpcodeEnum::ERROR) throw new ConnectionException($response->getData());
 		if (!empty($this->keyspace)) $this->setKeyspace($this->keyspace);


### PR DESCRIPTION
I found that if the user provided an incorrect password the error message received would be misleading; suggesting that credentials should be provided rather that the credentials being incorrect.
This is caused by the variable containing the response type not being updated following the login attempt when the first attempt at executing the query resulted in an AUTHENTICATE Opscode.

Before change...

``` bash
Fatal error: Uncaught exception 'evseevnn\Cassandra\Exception\CassandraException' with message 'Protocol error: Unexpected message QUERY, expecting CREDENTIALS'
```

After change...

``` bash
Fatal error: Uncaught exception 'evseevnn\Cassandra\Exception\ConnectionException' with message 'Bad credentials: Username and/or password are incorrect'
```
