### PR TITLE
Allow "COUNTER" batches (transactions)

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -109,6 +109,16 @@ class Database {
 	}
 
 	/**
+	 * Start counter transaction
+	 */
+	public function beginCounterBatch() {
+		if (!$this->batchQuery) {
+			$this->batchQuery = "BEING COUNTER BATCH\n";
+			$this->batchQueryData = [];
+		}
+	}
+
+	/**
 	 * Exec transaction
 	 */
 	public function applyBatch($consistency = ConsistencyEnum::CONSISTENCY_QUORUM) {


### PR DESCRIPTION
The implementation of the counter batches here utilizes a separate function to the existing `beginBatch()` function.

Another implementation could be to extend the existing function to take an optional "type" parameter which would be limited to values of "COUNTER" and "UNLOGGED' (see https://cassandra.apache.org/doc/cql3/CQL.html#batchStmt).
The batch query line would then become...

``` php
$this->batchQuery = "BEGIN $type BATCH\n";
```

I will be performing a lot of counter updates for specific events in an application and so Counter Batches are extremely useful to me... I believe this will provide additional value to other clients also.

Regards,
Adam
