### PR TITLE
0 - value integers(or numbers) read as null issue resolved

### DIFF
--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -67,9 +67,15 @@ class DataStream {
     public function readInt($isCollectionElement = false) {
         if ($isCollectionElement) {
             $length = $this->readShort();
-            return unpack('N', $this->read($length))[1];
+            $toReturn = unpack('l', strrev($this->read($length)))[1];
+			if($toReturn == -1)
+				$toReturn = 0;
+			return $toReturn;
         }
-        return unpack('N', $this->read(4))[1];
+        $toReturn = unpack('l', strrev($this->read(4)))[1];
+		if($toReturn == -1)
+				$toReturn = 0;
+		return $toReturn;
     }
 
 	/**
@@ -332,5 +338,48 @@ class DataStream {
 
 		trigger_error('Unknown type ' . var_export($type, true));
 		return null;
+	}
+
+	public function getTypeEmptyValue(array $type) {
+	  	switch ($type['type']) {
+	    	case DataTypeEnum::ASCII:
+	    	case DataTypeEnum::VARCHAR:
+	    	case DataTypeEnum::TEXT:
+	      		return null;
+		    case DataTypeEnum::BIGINT:
+		      return 0;
+		    case DataTypeEnum::COUNTER:
+		    case DataTypeEnum::VARINT:
+		      return 0;
+		    case DataTypeEnum::CUSTOM:
+		    case DataTypeEnum::BLOB:
+		      return null;
+		    case DataTypeEnum::BOOLEAN:
+		      return false;
+		    case DataTypeEnum::DECIMAL:
+		      return 0;
+		    case DataTypeEnum::DOUBLE:
+		      return 0;
+		    case DataTypeEnum::FLOAT:
+		      return 0;
+		    case DataTypeEnum::INT:
+		      return 0;
+		    case DataTypeEnum::TIMESTAMP:
+		      return 0;
+		    case DataTypeEnum::UUID:
+		      return null;
+		    case DataTypeEnum::TIMEUUID:
+		      return null;
+		    case DataTypeEnum::INET:
+		      return null;
+		    case DataTypeEnum::COLLECTION_LIST:
+		    case DataTypeEnum::COLLECTION_SET:
+		      return null;
+		    case DataTypeEnum::COLLECTION_MAP:
+		      return null;
+		  }
+
+	  trigger_error('Unknown type ' . var_export($type, true));
+	  return null;
 	}
 }

--- a/src/Protocol/Response/Rows.php
+++ b/src/Protocol/Response/Rows.php
@@ -38,7 +38,7 @@ class Rows implements \Iterator, \Countable {
 				try {
 					$row[$this->columns[$j]['name']] = $stream->readBytes();
 				} catch (\Exception $e) {
-					$row[$this->columns[$j]['name']] = null;
+					$row[$this->columns[$j]['name']] = $stream->getTypeEmptyValue($this->columns[$j]['type']);
 				}
 			}
 			$this->rows[] = $row;
@@ -63,7 +63,7 @@ class Rows implements \Iterator, \Countable {
 				$row[$this->columns[$i]['name']] = $data->readByType($this->columns[$i]['type']);
 			} catch (\Exception $e) {
 				trigger_error($e->getMessage());
-				$row[$this->columns[$i]['name']] = null;
+				$row[$this->columns[$i]['name']] = $data->getTypeEmptyValue($this->columns[$i]['type']);
 			}
 		}
 		return $row;


### PR DESCRIPTION
If in an int column (for example) a null value was inserted, that value
was read as null which was not correct.
If there were more columns after that one, everything was read as null,
even if values were actually there.
This issue happened for all types of numbers.

Follow this example to reproduce this issue:
------START------
------Create this table: ------
CREATE TABLE null_table_example(
  id int,
  col_str text,
  col_int1 int, 
  col_int 2 bigint,
  PRIMARY KEY (col_str)
);
------Run this insert: ------
insert into null_table_example (id, col_str, col_int1, col_int2) values (1, 'test1', null, 19);
------Run this query from php: ------
select \* from null_table_example where col_str = 'test1';
------END------

It will return good values for "id" and "col_str" but "col_int1" and "col_int2" will be null even if there are numbers; Executing this query from DataStax or DBeaver will return the correct values (0 for "col_int1" and 19 for "col_int2");

I've added a method that returns a sake value for null items depending of the data type.
Also, when a null was read, the size of it's byte value was -1, thing that leaded into putting all the rest of the columns after the null one into that one until it was converter from bytes and it becomed null, see my commit of DataStream.php;

Thanks!
