### PR TITLE
Revert 6f1cae9 because it caused a lot of troubles...

### DIFF
--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -74,7 +74,7 @@ class DataStream {
 			$length = $this->readShort();
 			return unpack('l', strrev($this->read($length)))[1];
 		}
-		return unpack('l', strrev($this->read(4)))[1];
+		return unpack('N', $this->read(4))[1];
 	}
 
 	/**


### PR DESCRIPTION
It fixes #35 

Someone should take a closer look at what the 6f1cae9 did intend to fix, and reapply a patch that does not break so fundamentally.

It might very be that these issues only affect more recent versions of cassandra, as not all users are experiencing them. See #35 and 6f1cae9 for more details.
