### PR TITLE
do not set a value if the column length is -1

### DIFF
--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -174,6 +174,10 @@ class DataStream {
 		if ($isCollectionElement)
 				$this->readShort();
 		$length = $this->readInt();
+
+		if ($length == -1)
+			return null;
+		
 		return $this->read($length);
 	}
 


### PR DESCRIPTION
If the value of a field is null the length is -1. So the following byte should not be readed. I've testet it with Cassandra Version 2.

Regards,
Pascal