### PR TITLE
Fix reading NULL Big Int data types.

### DIFF
--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -36,6 +36,10 @@ class DataStream {
 	 * @return string
 	 */
 	protected function read($length) {
+		if ( ! $length)	{
+			return null;
+		}
+		
 		if ($this->length < $length) {
 			throw new \Exception('Reading while at end of stream');
 		}

--- a/src/Protocol/Response/DataStream.php
+++ b/src/Protocol/Response/DataStream.php
@@ -174,6 +174,12 @@ class DataStream {
 		if ($isCollectionElement)
 				$this->readShort();
 		$length = $this->readInt();
+
+		if ($length === -1)
+		{
+			return null;
+		}
+
 		return $this->read($length);
 	}
 


### PR DESCRIPTION
There is a bug when you have a NULL column from Big Int data type. The code throws the message "Reading while at end of stream" and gives a PHP Notice.
To fix this, the protected function "read()" must check if the length of the data being read returns false. If the column is NULL, then $length will be 0 and the error will be thrown. 
This commit fixes this issue.