### PR TITLE
Allow to set connection snd/recv timeouts

### DIFF
--- a/src/Cluster/Node.php
+++ b/src/Cluster/Node.php
@@ -27,7 +27,9 @@ class Node {
 	 */
 	private $options = [
 		'username' => null,
-		'password' => null
+		'password' => null,
+		'rcvtimeo' => ["sec" => self::STREAM_TIMEOUT, "usec" => 0],
+		'sndtimeo' => ["sec" => self::STREAM_TIMEOUT, "usec" => 0]
 	];
 
 	/**
@@ -56,7 +58,8 @@ class Node {
 
 		$this->socket = socket_create(AF_INET, SOCK_STREAM, SOL_TCP);
 		socket_set_option($this->socket, getprotobyname('TCP'), TCP_NODELAY, 1);
-		socket_set_option($this->socket, SOL_SOCKET, SO_RCVTIMEO, ["sec" => self::STREAM_TIMEOUT, "usec" => 0]);
+		socket_set_option($this->socket, SOL_SOCKET, SO_RCVTIMEO, $this->options["rcvtimeo"]);
+		socket_set_option($this->socket, SOL_SOCKET, SO_SNDTIMEO, $this->options["sndtimeo"]);
 		if (!socket_connect($this->socket, $this->host, $this->port)) {
 			throw new ConnectionException("Unable to connect to Cassandra node: {$this->host}:{$this->port}");
 		}


### PR DESCRIPTION
When cassandra is unreachable this lib will end up in endless loop trying to connect. No exception will be raised.

Let's consider this simple example:

``` php
<?php

require 'vendor/autoload.php';
use \evseevnn\Cassandra\Database;

$database = new Database(['192.192.1.2:9042'], 'test');
echo "Connecting\n";
$database->connect();
echo "Connected\n";
```

When there are no network problems everything works fine:

> php test_cassandra.php 
> Connecting
> Connected

Let's fake network problems:

> sudo iptables -I INPUT -p tcp --dport 9042 -j DROP

And now our client will never connect and never raise exception.

> php test_cassandra.php
> Connecting
> ^C

After applying this fix an Exception will be raised.
