### PR TITLE
Preventing infinite hang on socket read

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PHP library for Cassandra
+DEATH ROW
 =========================
 
 [![Build Status](https://travis-ci.org/LarsFronius/php-cassandra-binary.svg?branch=master)](https://travis-ci.org/LarsFronius/php-cassandra-binary)

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -71,8 +71,13 @@ class Connection {
 	 */
 	private function fetchData($length) {
 		$data = socket_read($this->connection, $length);
+		$cleng = $length;
 		while (strlen($data) < $length) {
 			$data .= socket_read($this->connection, $length);
+			$cleng--;
+			if($cleng < 0){
+			    throw new ConnectionException('Timeout while consuming data from socket');
+			}
 		}
 		if (socket_last_error($this->connection) == 110) {
 			throw new ConnectionException('Connection timed out');


### PR DESCRIPTION
This was hanging for me pretty bad. I just added a quick check to see if the amount of iterations exceeds the total length passed to the method.

It should be safe to say, that if $cleng < 0, we aren't receiving data
from the socket. We should error, instead of infinitely hanging.

I think the error stems from having a bad rpc_address directive in the .yaml file (0.0.0.0) But either way, I think we should error, instead of hanging.
